### PR TITLE
Fix convex style for navbar toggle buttons

### DIFF
--- a/Assets/hr-micro.html
+++ b/Assets/hr-micro.html
@@ -201,14 +201,14 @@
                     }
                 </style>
                 <div class="navbar-mobile-actions">
-                    <button id="darkModeToggleNav" class="btn-custom download-btn ms-1 styled-button-convex"
+                    <button id="darkModeToggleNav" class="btn-custom download-btn ms-1"
                         style="border: none; min-width: fit-content; margin-right: 0.4rem;">
                         <i class="fas fa-moon"></i>
                     </button>
                     <!-- Language switch button -->
                     <!-- Language switch dropdown -->
                     <div class="custom-dropdown">
-                        <button id="languageSwitch" class="btn-custom download-btn ms-1 styled-button-convex"
+                        <button id="languageSwitch" class="btn-custom download-btn ms-1"
                             type="button" style="border: none; min-width: fit-content; margin-right: 1.4rem;">
                             <i class="fas fa-globe"></i>
                         </button>

--- a/Assets/itsm-micro.html
+++ b/Assets/itsm-micro.html
@@ -296,7 +296,7 @@
                     }
                 </style>
                 <div class="navbar-mobile-actions">
-                    <button id="darkModeToggleNav" class="btn-custom download-btn ms-1 styled-button-convex"
+                    <button id="darkModeToggleNav" class="btn-custom download-btn ms-1"
                         style="border: none; min-width: fit-content; margin-right: 0.4rem;">
                         <i class="fas fa-moon"></i>
                     </button>

--- a/Assets/realnet-micro.html
+++ b/Assets/realnet-micro.html
@@ -291,14 +291,14 @@
                     }
                 </style>
                 <div class="navbar-mobile-actions">
-                    <button id="darkModeToggleNav" class="btn-custom download-btn ms-1 styled-button-convex"
+                    <button id="darkModeToggleNav" class="btn-custom download-btn ms-1"
                         style="border: none; min-width: fit-content; margin-right: 0.4rem;">
                         <i class="fas fa-moon"></i>
                     </button>
                     <!-- Language switch button -->
                     <!-- Language switch dropdown -->
                     <div class="custom-dropdown">
-                        <button id="languageSwitch" class="btn-custom download-btn ms-1 styled-button-convex"
+                        <button id="languageSwitch" class="btn-custom download-btn ms-1"
                             type="button" style="border: none; min-width: fit-content; margin-right: 1.4rem;">
                             <i class="fas fa-globe"></i>
                         </button>


### PR DESCRIPTION
## Summary
- remove `styled-button-convex` from dark mode and language buttons

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683ffc438c348327a02ffd522c2320f3