### PR TITLE
Fix carousel text styles on micro pages

### DIFF
--- a/Assets/micro/bimasakti/index.html
+++ b/Assets/micro/bimasakti/index.html
@@ -1466,7 +1466,6 @@
             }
 
             .carousel-content-left p {
-                font-size: 20px !important;
                 margin-bottom: 2rem;
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
                 line-height: 1.6;

--- a/Assets/micro/golf/index.html
+++ b/Assets/micro/golf/index.html
@@ -1244,7 +1244,6 @@
             }
 
             .carousel-content-left p {
-                font-size: 20px !important;
                 margin-bottom: 2rem;
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
                 line-height: 1.6;

--- a/Assets/micro/hr/index.html
+++ b/Assets/micro/hr/index.html
@@ -1237,7 +1237,6 @@
             }
 
             .carousel-content-left p {
-                font-size: 20px;
                 margin-bottom: 2rem;
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
                 line-height: 1.6;

--- a/Assets/micro/itsm/index.html
+++ b/Assets/micro/itsm/index.html
@@ -1448,7 +1448,6 @@
             }
 
             .carousel-content-left p {
-                font-size: 20px !important;
                 margin-bottom: 2rem;
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
                 line-height: 1.6;

--- a/Assets/micro/realnet/index.html
+++ b/Assets/micro/realnet/index.html
@@ -1443,7 +1443,6 @@
             }
 
             .carousel-content-left p {
-                font-size: 20px !important;
                 margin-bottom: 2rem;
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
                 line-height: 1.6;

--- a/Assets/micro/rhapsody/index.html
+++ b/Assets/micro/rhapsody/index.html
@@ -1345,7 +1345,6 @@
             }
 
             .carousel-content-left p {
-                font-size: 20px !important;
                 margin-bottom: 2rem;
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
                 line-height: 1.6;


### PR DESCRIPTION
## Summary
- remove hardcoded font-size from carousel paragraphs on micro pages
- rely on `.lead` class for responsive font sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841eaa57adc83279cabfe9e28d805f4