### PR TITLE
Fix sidebar font overrides

### DIFF
--- a/Assets/micro/bimasakti/index.html
+++ b/Assets/micro/bimasakti/index.html
@@ -359,7 +359,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#gcsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Golf Course Management System<i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -389,7 +389,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hmsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Hotel Management System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hmsSubmenu" class="collapse product-submenu">
@@ -419,7 +419,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hrSystemSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 HR System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hrSystemSubmenu" class="collapse product-submenu">
@@ -449,7 +449,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#itsmSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 ITSM, ITAM & Unified Endpoint Management <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -481,7 +481,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#erpSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Network & System Integration <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -515,7 +515,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#propertyTenantSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Property and Tenant System <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>

--- a/Assets/micro/erp/index.html
+++ b/Assets/micro/erp/index.html
@@ -223,7 +223,7 @@
                                     <li>
                                         <div class="product-header" data-bs-toggle="collapse"
                                             data-bs-target="#gcsSubmenu" aria-expanded="false"
-                                            style="font-size: 1rem; font-weight: 400;">
+                                            style="font-weight: 400;">
                                             Golf Course Management System<i class="fas fa-chevron-right arrow-icon"></i>
                                         </div>
                                         <div id="gcsSubmenu" class="collapse product-submenu">
@@ -251,7 +251,7 @@
                                     <li>
                                         <div class="product-header" data-bs-toggle="collapse"
                                             data-bs-target="#hmsSubmenu" aria-expanded="false"
-                                            style="font-size: 1rem; font-weight: 400;">
+                                            style="font-weight: 400;">
                                             Hotel Management System <i class="fas fa-chevron-right arrow-icon"></i>
                                         </div>
                                         <div id="hmsSubmenu" class="collapse product-submenu">
@@ -278,7 +278,7 @@
                                     <li>
                                         <div class="product-header" data-bs-toggle="collapse"
                                             data-bs-target="#hrSystemSubmenu" aria-expanded="false"
-                                            style="font-size: 1rem; font-weight: 400;">
+                                            style="font-weight: 400;">
                                             HR System <i class="fas fa-chevron-right arrow-icon"></i>
                                         </div>
                                         <div id="hrSystemSubmenu" class="collapse product-submenu">
@@ -305,7 +305,7 @@
                                      <li>
                                         <div class="product-header" data-bs-toggle="collapse"
                                             data-bs-target="#itsmSubmenu" aria-expanded="false"
-                                            style="font-size: 1rem; font-weight: 400;">
+                                            style="font-weight: 400;">
                                             ITSM, ITAM & Unified Endpoint Management <i
                                                 class="fas fa-chevron-right arrow-icon"></i>
                                         </div>
@@ -334,7 +334,7 @@
                                     <li>
                                         <div class="product-header" data-bs-toggle="collapse"
                                             data-bs-target="#erpSubmenu" aria-expanded="false"
-                                            style="font-size: 1rem; font-weight: 400;">
+                                            style="font-weight: 400;">
                                             Network & System Integration <i class="fas fa-chevron-right arrow-icon"></i>
                                         </div>
                                         <div id="erpSubmenu" class="collapse product-submenu">
@@ -362,7 +362,7 @@
                                     <li>
                                         <div class="product-header" data-bs-toggle="collapse"
                                             data-bs-target="#propertyTenantSubmenu" aria-expanded="false"
-                                            style="font-size: 1rem; font-weight: 400;">
+                                            style="font-weight: 400;">
                                             Property and Tenant System <i class="fas fa-chevron-right arrow-icon"></i>
                                         </div>
                                         <div id="propertyTenantSubmenu" class="collapse product-submenu">

--- a/Assets/micro/golf/index.html
+++ b/Assets/micro/golf/index.html
@@ -300,7 +300,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#gcsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Golf Course Management System<i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -331,7 +331,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hmsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Hotel Management System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hmsSubmenu" class="collapse product-submenu">
@@ -362,7 +362,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hrSystemSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 HR System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hrSystemSubmenu" class="collapse product-submenu">
@@ -392,7 +392,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#itsmSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 ITSM, ITAM & Unified Endpoint Management <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -425,7 +425,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#erpSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Network & System Integration <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -461,7 +461,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#propertyTenantSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Property and Tenant System <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>

--- a/Assets/micro/hr/index.html
+++ b/Assets/micro/hr/index.html
@@ -246,7 +246,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#gcsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Golf Course Management System<i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -276,7 +276,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hmsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Hotel Management System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hmsSubmenu" class="collapse product-submenu">
@@ -306,7 +306,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hrSystemSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 HR System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hrSystemSubmenu" class="collapse product-submenu">
@@ -336,7 +336,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#itsmSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 ITSM, ITAM & Unified Endpoint Management <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -368,7 +368,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#erpSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Network & System Integration <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -402,7 +402,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#propertyTenantSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Property and Tenant System <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>

--- a/Assets/micro/itsm/index.html
+++ b/Assets/micro/itsm/index.html
@@ -340,7 +340,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#gcsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Golf Course Management System<i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -370,7 +370,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hmsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Hotel Management System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hmsSubmenu" class="collapse product-submenu">
@@ -400,7 +400,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hrSystemSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 HR System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hrSystemSubmenu" class="collapse product-submenu">
@@ -430,7 +430,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#itsmSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 ITSM, ITAM & Unified Endpoint Management <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -462,7 +462,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#erpSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Network & System Integration <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -496,7 +496,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#propertyTenantSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Property and Tenant System <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>

--- a/Assets/micro/realnet/index.html
+++ b/Assets/micro/realnet/index.html
@@ -335,7 +335,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#gcsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Golf Course Management System<i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -365,7 +365,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hmsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Hotel Management System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hmsSubmenu" class="collapse product-submenu">
@@ -395,7 +395,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hrSystemSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 HR System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hrSystemSubmenu" class="collapse product-submenu">
@@ -425,7 +425,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#itsmSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 ITSM, ITAM & Unified Endpoint Management <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -457,7 +457,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#erpSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Network & System Integration <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -491,7 +491,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#propertyTenantSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Property and Tenant System <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>

--- a/Assets/micro/rhapsody/index.html
+++ b/Assets/micro/rhapsody/index.html
@@ -144,7 +144,7 @@
             transition: all 0.3s ease !important;
             padding: 10px 18px !important;
             font-weight: 600 !important;
-            font-size: 16x !important;
+            font-size: 16px !important;
             border-radius: 10px !important;
         }
 
@@ -324,7 +324,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#gcsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Golf Course Management System<i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -354,7 +354,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hmsSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Hotel Management System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hmsSubmenu" class="collapse product-submenu">
@@ -384,7 +384,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#hrSystemSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 HR System <i class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
                                             <div id="hrSystemSubmenu" class="collapse product-submenu">
@@ -414,7 +414,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#itsmSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 ITSM, ITAM & Unified Endpoint Management <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -446,7 +446,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#erpSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Network & System Integration <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>
@@ -480,7 +480,7 @@
                                         <li>
                                             <div class="product-header" data-bs-toggle="collapse"
                                                 data-bs-target="#propertyTenantSubmenu" aria-expanded="false"
-                                                style="font-size: 1rem; font-weight: 400;">
+                                                style="font-weight: 400;">
                                                 Property and Tenant System <i
                                                     class="fas fa-chevron-right arrow-icon"></i>
                                             </div>


### PR DESCRIPTION
## Summary
- remove inline `font-size` from sidebar headers across micro pages
- correct invalid `font-size: 16x` typo on the Rhapsody page

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841f745d3ec8327af80b4eef48782b4