### PR TITLE
Fix golf carousel opacity

### DIFF
--- a/Assets/micro/golf/index.html
+++ b/Assets/micro/golf/index.html
@@ -1450,7 +1450,7 @@
         }
 
         .carousel-fade .carousel-item {
-            opacity: 0;
+            opacity: 1;
             transition: opacity 1s cubic-bezier(0.4, 0, 0.2, 1);
             will-change: opacity;
             backface-visibility: hidden;


### PR DESCRIPTION
## Summary
- keep golf carousel items fully opaque like other micros

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68445f7dae4c8327ab891ad0211c94a9